### PR TITLE
fix(backend): add missing pydantic-settings dependency for Vercel runtime

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,5 @@ typing-extensions
 
 # If you're using file uploads anywhere (FastAPI forms)
 python-multipart
+
+pydantic-settings


### PR DESCRIPTION
Fixes backend deployment failure on Vercel caused by missing pydantic-settings dependency. The app was crashing at import time in config.py, resulting in 500 errors for all routes. This adds the required package to ensure environment-based settings load correctly in production.